### PR TITLE
Add worker login UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,29 +9,32 @@
 <body>
     <div class="container">
         <h1>Time Clock</h1>
-        <div id="clockStatus">
-            <p>Current Status: <span id="currentStatusText">Not Clocked In</span></p>
-            <p>Project: <span id="currentProjectText">-</span></p>
-            <p>Clocked In At: <span id="clockInTimeText">-</span></p>
-        </div>
-        <hr>
-
-        <!-- Assume worker ID is known, e.g., from a login or selection -->
-
-
-        <div>
-            <label for="projectSelect">Select Project:</label>
-            <select id="projectSelect">
-                <option value="">Loading projects...</option>
-            </select>
+        <div id="loginSection">
+            <label for="workerLoginInput">Worker Email or Employee ID:</label>
+            <input type="text" id="workerLoginInput">
+            <button id="workerLoginBtn">Login</button>
         </div>
 
-        <button id="clockInBtn">Clock In</button>
-        <button id="clockOutBtn" style="display:none;">Clock Out</button>
+        <div id="clockSection" style="display:none;">
+            <input type="hidden" id="workerId" value="">
+            <div id="clockStatus">
+                <p>Current Status: <span id="currentStatusText">Not Clocked In</span></p>
+                <p>Project: <span id="currentProjectText">-</span></p>
+                <p>Clocked In At: <span id="clockInTimeText">-</span></p>
+            </div>
+            <hr>
+            <div id="projectRadios"></div>
+            <div>
+                <label for="noteInput">Note:</label>
+                <input type="text" id="noteInput">
+            </div>
+            <button id="clockInBtn">Clock In</button>
+            <button id="clockOutBtn" style="display:none;">Clock Out</button>
+            <p><a href="worker_view.html">View My Hours</a></p>
+            <p><a href="admin_login.html">Admin Login</a></p>
+        </div>
 
         <div id="messageArea" class="message" style="display:none;"></div>
-        <p><a href="worker_view.html">View My Hours</a></p>
-        <p><a href="admin_login.html">Admin Login</a></p>
     </div>
     <script src="js/utils.js"></script>
     <script src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- add missing login section and fields in `frontend/index.html`
- ensure login flow hides login section after user login

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841e131cab4832c87bc4ff5b67874c6